### PR TITLE
View count on home page

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -77,5 +77,35 @@ class ETPlugin_Views extends ETPlugin {
 		$search->orderBy("c.views ".($negate ? "ASC" : "DESC"));
 		$search->sql->useIndex("conversation_views");
 	}
+	
+	// Construct and process the settings form.
+	public function settings($sender)
+	{
+		// Set up the settings form.
+		$form = ETFactory::make("form");
+		$form->action = URL("admin/plugins/settings/Views");
+		$form->setValue("allowSearchViews",C("plugin.Views.allowSearchViews"));
+
+		// If the form was submitted...
+		if ($form->validPostBack("viewsSave")) {
+
+			// Construct an array of config options to write.
+			$config = array();
+			$config["plugin.Views.allowSearchViews"] = $form->getValue("allowSearchViews");
+
+			if (!$form->errorCount()) {
+
+				// Write the config file.
+				ET::writeConfig($config);
+
+				$sender->message(T("message.changesSaved"), "success autoDismiss");
+				$sender->redirect(URL("admin/plugins"));
+
+			}
+		}
+
+		$sender->data("viewsSettingsForm", $form);
+		return $this->view("settings");
+	}
 
 }

--- a/views/conversations/conversation.php
+++ b/views/conversations/conversation.php
@@ -1,0 +1,76 @@
+<?php
+// Copyright 2011 Toby Zerner, Simon Zerner
+// This file is part of esoTalk. Please see the included license file for usage information.
+
+if (!defined("IN_ESOTALK")) exit;
+
+/**
+ * Displays a single conversation row in the context of a list of results.
+ *
+ * @package esoTalk
+ */
+
+$conversation = $data["conversation"];
+
+// Work out the class name to apply to the row.
+$className = "channel-".$conversation["channelId"];
+if ($conversation["starred"]) $className .= " starred";
+if ($conversation["unread"] and ET::$session->user) $className .= " unread";
+if ($conversation["startMemberId"] == ET::$session->user) $className .= " mine";
+foreach ($conversation["labels"] as $label) $className .= " label-$label";
+
+?>
+<li id='c<?php echo $conversation["conversationId"]; ?>' class='<?php echo $className; ?>'>
+<?php if (ET::$session->user): ?>
+<div class='col-star'><?php
+echo star($conversation["conversationId"], $conversation["starred"]);
+
+// Output an "unread indicator", allowing the user to mark the conversation as read.
+if (ET::$session->user and $conversation["unread"])
+	echo " <a href='".URL("conversation/markAsRead/".$conversation["conversationId"]."?token=".ET::$session->token."&return=".urlencode(ET::$controller->selfURL))."' class='unreadIndicator' title='".T("Mark as read")."'><i class='icon-ok'></i></a> ";
+?></div>
+<?php endif; ?>
+<div class='col-conversation'><?php
+$conversationURL = conversationURL($conversation["conversationId"], $conversation["title"]);
+
+// Output the conversation's labels.
+echo "<span class='labels'>";
+foreach ($conversation["labels"] as $label) echo label($label, $label == "draft" ? URL($conversationURL."#reply") : "");
+echo "</span> ";
+
+// Output the conversation title, highlighting search keywords.
+echo "<strong class='title'><a href='".URL($conversationURL.((ET::$session->user and $conversation["unread"]) ? "/unread" : ""))."'>".highlight(sanitizeHTML($conversation["title"]), ET::$session->get("highlight"))."</a></strong> ";
+
+// If we're highlighting search terms (i.e. if we did a fulltext search), then output a "show matching posts" link.
+if (ET::$session->get("highlight"))
+	echo "<span class='controls'><a href='".URL($conversationURL."/?search=".urlencode($data["fulltextString"]))."' class='showMatchingPosts'>".T("Show matching posts")."</a></span>";
+
+// If this conversation is stickied, output an excerpt from its first post.
+if ($conversation["sticky"])
+	echo "<div class='excerpt'>".ET::formatter()->init($conversation["firstPost"])->inline(true)->firstLine()->clip(200)->format()->get()."</div>";
+
+// Show view count on home page or search results of conversations (if config is set as enabled)
+
+if(C("plugin.Views.allowSearchViews")) echo "<span style='float:right;color:#999999'>".Ts("%s view", "%s views", $data["conversation"]["views"])."</span>";
+
+?></div>
+<div class='col-channel'><?php
+$channel = $data["channelInfo"][$conversation["channelId"]];
+echo "<a href='".URL(searchURL("", $channel["slug"]))."' class='channel channel-{$conversation["channelId"]}' data-channel='{$channel["slug"]}'>{$channel["title"]}</a>";
+?></div>
+<div class='col-lastPost'><?php
+echo "<span class='action'>".avatar(array(
+		"memberId" => $conversation["lastPostMemberId"],
+		"username" => $conversation["lastPostMember"],
+		"avatarFormat" => $conversation["lastPostMemberAvatarFormat"],
+		"email" => $conversation["lastPostMemberEmail"]
+	), "thumb"), " ",
+	sprintf(T("%s posted %s"),
+		"<span class='lastPostMember name'>".memberLink($conversation["lastPostMemberId"], $conversation["lastPostMember"])."</span>",
+		"<a href='".URL($conversationURL."/unread")."' class='lastPostTime'>".relativeTime($conversation["lastPostTime"], true)."</a>"),
+	"</span>";
+?></div>
+<div class='col-replies'><?php
+echo "<span><a href='".URL($conversationURL."/unread")."'>".$conversation["replies"]."</a></span>";
+?></div>
+</li>

--- a/views/settings.php
+++ b/views/settings.php
@@ -1,0 +1,37 @@
+<?php
+// Made on August 1, 2015 by yathish
+// Built on settings page of attachments plugin
+
+if (!defined("IN_ESOTALK")) exit;
+
+/**
+ * Displays the settings form for the Views plugin.
+ *
+ * @package esoTalk
+ */
+
+$form = $data["viewsSettingsForm"];
+?>
+<?php echo $form->open(); ?>
+
+<div class='section'>
+
+<ul class='form'>
+
+<li>
+<!-- Show checkbox for admin to enable/disable showing view count in search results (home page as well) 
+-->
+<?php echo $form->checkbox("allowSearchViews"); ?>
+<label>Conversation Views</label>
+<small><?php echo T("Show view count on home page conversations list. <br>View count wil also be shown in search results."); ?></small>
+</li>
+
+</ul>
+
+</div>
+
+<div class='buttons'>
+<?php echo $form->saveButton("viewsSave"); ?>
+</div>
+
+<?php echo $form->close(); ?>


### PR DESCRIPTION
Just a minor enhancement for the plugin.

Enhancement is to show view count on each conversation on home page. Effectively, view count is also shown on search results page for conversations.
![image](https://cloud.githubusercontent.com/assets/10807784/9021194/a55fded6-3853-11e5-9718-c05328b88a5c.png)

Added settings pane for admin, where admin can enable/disable this enhancement. By default it is disabled.
![image](https://cloud.githubusercontent.com/assets/10807784/9021197/ca6f6386-3853-11e5-9f89-d4585ccda7ea.png)
